### PR TITLE
🔀 :: (#3) business logic utility

### DIFF
--- a/data/src/main/java/com/semicolon/data/util/OfflineCacheUtil.kt
+++ b/data/src/main/java/com/semicolon/data/util/OfflineCacheUtil.kt
@@ -1,0 +1,44 @@
+package com.semicolon.data.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.lang.NullPointerException
+
+class OfflineCacheUtil<T> {
+
+    private lateinit var fetchLocalData: suspend () -> T
+    private lateinit var fetchRemoteData: suspend () -> T
+    private var isNeedRefresh: suspend (localData: T, remoteData: T) -> Boolean =
+        { localData, remoteData -> localData != remoteData }
+    private lateinit var refreshLocalData: suspend (remoteData: T) -> Unit
+
+    fun localData(fetchLocalData: suspend () -> T): OfflineCacheUtil<T> =
+        this.apply { this.fetchLocalData = fetchLocalData }
+
+    fun remoteData(fetchRemoteData: suspend () -> T): OfflineCacheUtil<T> =
+        this.apply { this.fetchRemoteData = fetchRemoteData }
+
+    fun compareData(isNeedRefresh: suspend (localData: T, remoteData: T) -> Boolean): OfflineCacheUtil<T> =
+        this.apply { this.isNeedRefresh = isNeedRefresh }
+
+    fun doOnNeedRefresh(refreshLocalData: suspend (remoteData: T) -> Unit): OfflineCacheUtil<T> =
+        this.apply { this.refreshLocalData = refreshLocalData }
+
+    fun createFlow(): Flow<T> =
+        flow {
+            try {
+                val localData = fetchLocalData()
+                emit(localData)
+
+                val remoteData = fetchRemoteData()
+                if (isNeedRefresh(localData, remoteData)) {
+                    refreshLocalData(remoteData)
+                    emit(remoteData)
+                }
+            } catch (e: NullPointerException) {
+                val remoteData = fetchRemoteData()
+                refreshLocalData(remoteData)
+                emit(remoteData)
+            }
+        }
+}

--- a/domain/src/main/java/com/semicolon/domain/usecase/UseCase.kt
+++ b/domain/src/main/java/com/semicolon/domain/usecase/UseCase.kt
@@ -1,0 +1,5 @@
+package com.semicolon.domain.usecase
+
+abstract class UseCase<I, O> {
+    abstract suspend fun execute(data: I): O
+}


### PR DESCRIPTION
## 개요
> 비즈니스 로직에서 중복 코드를 줄이거나 코드의 일관성을 갖추기 위해 필요한
유틸리티 코드를 작성합니다

## 작업사항
- use case의 추상 클래스 추가
- 데이터를 가져올 때 general 하게 사용할 수 있는 OfflineCacheUtil 추가


