### PR TITLE
🔀 :: (#479) measure exercise crash

### DIFF
--- a/data/src/main/java/com/semicolon/data/local/storage/FitnessDataStorageImpl.kt
+++ b/data/src/main/java/com/semicolon/data/local/storage/FitnessDataStorageImpl.kt
@@ -65,16 +65,16 @@ class FitnessDataStorageImpl @Inject constructor(
                 var calories: Float
                 data.addOnSuccessListener {
                     steps = it.buckets.firstOrNull()
-                        ?.getDataSet(DataType.AGGREGATE_STEP_COUNT_DELTA)!!.dataPoints.firstOrNull()
+                        ?.getDataSet(DataType.AGGREGATE_STEP_COUNT_DELTA)?.dataPoints?.firstOrNull()
                         ?.getValue(Field.FIELD_STEPS)?.asInt() ?: 0
                     minutes = it.buckets.firstOrNull()
-                        ?.getDataSet(DataType.AGGREGATE_MOVE_MINUTES)!!.dataPoints.firstOrNull()
+                        ?.getDataSet(DataType.AGGREGATE_MOVE_MINUTES)?.dataPoints?.firstOrNull()
                         ?.getValue(Field.FIELD_DURATION)?.asInt() ?: 0
                     distance = it.buckets.firstOrNull()
-                        ?.getDataSet(DataType.AGGREGATE_DISTANCE_DELTA)!!.dataPoints.firstOrNull()
+                        ?.getDataSet(DataType.AGGREGATE_DISTANCE_DELTA)?.dataPoints?.firstOrNull()
                         ?.getValue(Field.FIELD_DISTANCE)?.asFloat()?.toInt() ?: 0
                     calories = it.buckets.firstOrNull()
-                        ?.getDataSet(DataType.AGGREGATE_CALORIES_EXPENDED)!!.dataPoints.firstOrNull()
+                        ?.getDataSet(DataType.AGGREGATE_CALORIES_EXPENDED)?.dataPoints?.firstOrNull()
                         ?.getValue(Field.FIELD_CALORIES)?.asFloat() ?: 0f
 
                     trySend(
@@ -137,13 +137,13 @@ class FitnessDataStorageImpl @Inject constructor(
         return suspendCoroutine {
             data.addOnSuccessListener { response ->
                 val steps = response.buckets.firstOrNull()
-                    ?.getDataSet(DataType.AGGREGATE_STEP_COUNT_DELTA)!!.dataPoints.firstOrNull()
+                    ?.getDataSet(DataType.AGGREGATE_STEP_COUNT_DELTA)?.dataPoints?.firstOrNull()
                     ?.getValue(Field.FIELD_STEPS)?.asInt() ?: 0
                 val distance = response.buckets.firstOrNull()
-                    ?.getDataSet(DataType.AGGREGATE_DISTANCE_DELTA)!!.dataPoints.firstOrNull()
+                    ?.getDataSet(DataType.AGGREGATE_DISTANCE_DELTA)?.dataPoints?.firstOrNull()
                     ?.getValue(Field.FIELD_DISTANCE)?.asFloat()?.toInt() ?: 0
                 val calories = response.buckets.firstOrNull()
-                    ?.getDataSet(DataType.AGGREGATE_CALORIES_EXPENDED)!!.dataPoints.firstOrNull()
+                    ?.getDataSet(DataType.AGGREGATE_CALORIES_EXPENDED)?.dataPoints?.firstOrNull()
                     ?.getValue(Field.FIELD_CALORIES)?.asFloat() ?: 0f
 
                 it.resume(


### PR DESCRIPTION
## 개요
> 운동 측정 과정에서 크래쉬 발생

## 작업사항
- 측정 화면 진입할 때 크래쉬 해결
- 일시중지/재시작 반복 시 발생하는 크래쉬 해결

## 변경로직
- 무지성 널체크 해결
- end time이 start time보다 클때만 google fit에 데이터 요청